### PR TITLE
BUGFIX: Error when GPX contains only one coordinate

### DIFF
--- a/R/process_data.R
+++ b/R/process_data.R
@@ -19,7 +19,9 @@ process_data <- function(path) {
 
     # Check for empty file.
     if (length(coords) == 0) return(NULL)
-    #
+    # dist_to_prev computation requires that there be at least two coordinates.
+    if (ncol(coords) < 2) return(NULL)
+
     lat <- as.numeric(coords["lat", ])
     lon <- as.numeric(coords["lon", ])
     ele <- as.numeric(XML::xpathSApply(pfile, path = "//trkpt/ele", XML::xmlValue))


### PR DESCRIPTION
An edgecase causes a crash in process_data on files that contain only one coordinate.

Since distance computations require at least 2 coordinates, I added it as a precondition.

Tested with
`install_github("RyanRosario/strava", ref="rrr")`

Test case:
```
<?xml version="1.0" encoding="UTF-8"?>
<gpx creator="StravaGPX iPhone" version="1.1" xmlns="http://www.topografix.com/GPX/1/1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd">
 <metadata>
  <time>2013-08-11T22:51:20Z</time>
 </metadata>
 <trk>
  <name>Afternoon Ride</name>
  <trkseg>
   <trkpt lat="37" lon="-122">
    <ele>24.5</ele>
    <time>2013-08-11T22:51:20Z</time>
   </trkpt>
  </trkseg>
 </trk>
</gpx>
```