### PR TITLE
fix the activity id mapping

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: strava
 Title: Create Artistic Visualisations with your Strava Exercise Data
-Version: 0.0.0.9000
+Version: 0.0.0.9001
 Authors@R: person("Marcus", "Volz", email = "marcus.volz@outlook.com", role = c("aut", "cre"))
 Description: Creates artistic visualisations with Strava data.
 Depends: R (>= 3.4.3)
@@ -9,7 +9,8 @@ Imports:
     ggplot2,
     purrr,
     sp,
-    XML
+    XML,
+    stringr
 License: What license is it under?
 Encoding: UTF-8
 LazyData: true


### PR DESCRIPTION
Extracts the activity id from the activity file name, and adds it to the dataframe produced by `process_gpx`. This allows users to join the meta data in `activities.csv` to the dataframe generated by `process_data`, by `id`.

## Example

```r
library(strava)
library(readr)
library(dplyr)

gpx_data <- process_data(<path to activities>)
activity_meta_data <- read_csv(<path to activities.csv>)

new_df <- gpx_data %>%
    left_join(activity_meta_data, by = "id")
```

This new dataframe opens the door to colour coding activities by type for example.