### PR TITLE
Allow track size to be absolute in plot_facets

### DIFF
--- a/R/plot_facets.R
+++ b/R/plot_facets.R
@@ -36,6 +36,10 @@ plot_facets <- function(data, labels = FALSE, scales = "free") {
                    strip.background = ggplot2::element_blank(),
                    strip.text = ggplot2::element_blank(),
                    plot.margin = ggplot2::unit(rep(1, 4), "cm"))
+  
+  if (scales == "fixed") {
+    p <- p + ggplot2::coord_fixed() # make aspect ratio == 1
+  }
 
   # Add labels
   if(labels) {

--- a/R/plot_facets.R
+++ b/R/plot_facets.R
@@ -3,23 +3,34 @@
 #' Creates a plot of activities as small multiples. The concept behind this plot was originally inspired by \href{https://www.madewithsisu.com/}{Sisu}.
 #' @param data A data frame output from process_data()
 #' @param labels If TRUE, adds distance labels to each facet
+#' @param scales If "fixed", track size reflects absolute distance travelled
 #' @keywords
 #' @export
 #' @examples
 #' plot_facets()
 
-plot_facets <- function(data, labels = FALSE) {
+plot_facets <- function(data, labels = FALSE, scales = "free") {
   # Summarise data
   summary <- data %>%
     dplyr::group_by(id) %>%
     dplyr::summarise(lon = mean(range(lon)),
                      lat = mean(range(lat)),
                      distance = sprintf("%.1f", max(cumdist)))
+  
+  # Decide if tracks will all be scaled to similar size ("free") or if
+  # track sizes reflect absolute distance in each dimension ("fixed")
+  if (scales == "fixed") {
+    data <- data %>% dplyr::group_by(id) %>% # for each track,
+      dplyr::mutate(lon = lon - mean(lon), # centre data on zero so facets can
+                    lat = lat - mean(lat)) # be plotted on same distance scale
+  } else {
+    scales = "free" # default, in case a non-valid option was specified
+  }
 
   # Create plot
   p <- ggplot2::ggplot() +
     ggplot2::geom_path(ggplot2::aes(lon, lat, group = id), data, size = 0.35, lineend = "round") +
-    ggplot2::facet_wrap(~id, scales = "free") +
+    ggplot2::facet_wrap(~id, scales = scales) +
     ggplot2::theme_void() +
     ggplot2::theme(panel.spacing = ggplot2::unit(0, "lines"),
                    strip.background = ggplot2::element_blank(),


### PR DESCRIPTION
Currently `plot_facets()` uses free scales for each facet, so that all tracks appear to be of a similar size in both x and y dimensions. Here we add a new argument `scales`. This defaults to a value of "free", which gives the current behaviour. With a value of "fixed" the scales are set to "fixed" for each facet, so that longer tracks do actually appear to be larger than tracks that covered less distance.  This requires that all points within a track must be normalised by centering all latitude and longitude values about a mean of zero, allowing each facet to share the same axis ranges. This also means that the x and y axes should be on the same scale, so the aspect ratio of each track is veridical, rather than each dimension being stretched to fill out each facet, which happens with "free" scales.