### PR TITLE
remove not working examples

### DIFF
--- a/R/plot_calendar.R
+++ b/R/plot_calendar.R
@@ -5,8 +5,6 @@
 #'
 #' @return A plot displaying calendar heat map
 #' @export
-#'
-#' @examples
 plot_calendar <- function(data, unit = "distance") {
   if (!(unit %in% c("distance", "time"))) {
     stop("This unit doesn't exist! Use 'time' or 'distance' instead!")

--- a/R/plot_elevations.R
+++ b/R/plot_elevations.R
@@ -5,9 +5,6 @@
 #' @param scale_free_y If TRUE, the y-scale is "free"; otherwise it is "fixed"
 #' @keywords
 #' @export
-#' @examples
-#' plot_elevations()
-
 plot_elevations <- function(data, scale_free_y = FALSE) {
   # Compute total distance for each activity
   dist <- data %>%

--- a/R/plot_facets.R
+++ b/R/plot_facets.R
@@ -6,9 +6,6 @@
 #' @param scales If "fixed", track size reflects absolute distance travelled
 #' @keywords
 #' @export
-#' @examples
-#' plot_facets()
-
 plot_facets <- function(data, labels = FALSE, scales = "free") {
   # Summarise data
   summary <- data %>%
@@ -16,7 +13,7 @@ plot_facets <- function(data, labels = FALSE, scales = "free") {
     dplyr::summarise(lon = mean(range(lon)),
                      lat = mean(range(lat)),
                      distance = sprintf("%.1f", max(cumdist)))
-  
+
   # Decide if tracks will all be scaled to similar size ("free") or if
   # track sizes reflect absolute distance in each dimension ("fixed")
   if (scales == "fixed") {
@@ -36,7 +33,7 @@ plot_facets <- function(data, labels = FALSE, scales = "free") {
                    strip.background = ggplot2::element_blank(),
                    strip.text = ggplot2::element_blank(),
                    plot.margin = ggplot2::unit(rep(1, 4), "cm"))
-  
+
   if (scales == "fixed") {
     p <- p + ggplot2::coord_fixed() # make aspect ratio == 1
   }

--- a/R/plot_map.R
+++ b/R/plot_map.R
@@ -9,8 +9,6 @@
 #'
 #' @return A heat map of activities
 #' @export
-#'
-#' @examples
 plot_map <- function(data, lon_min = NA, lat_min = NA, lon_max = NA, lat_max = NA) {
   data %>%
     ggplot(aes(lon, lat, group = id)) +

--- a/R/plot_packed_circles.R
+++ b/R/plot_packed_circles.R
@@ -6,8 +6,6 @@
 #'
 #' @return A plot with Strava activities as packed circles
 #' @export
-#'
-#' @examples
 plot_packed_circles <- function(data, circle_size = "duration", circle_fill = "distance") {
   # ---- functions ----
   compute_cluster <- function(cluster_year) {

--- a/R/plot_ridges.R
+++ b/R/plot_ridges.R
@@ -4,8 +4,6 @@
 #'
 #' @return A plot displaying ridges
 #' @export
-#'
-#' @examples
 plot_ridges <- function(data) {
   # Function for processing an activity on a minute-by-minute basis; active = 1, not active = 0
   compute_day_curve <- function(df_row) {

--- a/R/process_data.R
+++ b/R/process_data.R
@@ -5,9 +5,6 @@
 #' @param old_gpx_format If TRUE, uses the old format for gpx files (for files bulk exported from Strava prior to ~May 2018)
 #' @keywords
 #' @export
-#' @examples
-#' process_data()
-
 process_data <- function(path, old_gpx_format = FALSE) {
   # Function for processing a Strava gpx file
   process_gpx <- function(file) {

--- a/man/plot_elevations.Rd
+++ b/man/plot_elevations.Rd
@@ -14,6 +14,3 @@ plot_elevations(data, scale_free_y = FALSE)
 \description{
 Creates a plot of elevation profiles as small multiples
 }
-\examples{
-plot_elevations()
-}

--- a/man/plot_facets.Rd
+++ b/man/plot_facets.Rd
@@ -16,6 +16,3 @@ plot_facets(data, labels = FALSE, scales = "free")
 \description{
 Creates a plot of activities as small multiples. The concept behind this plot was originally inspired by \href{https://www.madewithsisu.com/}{Sisu}.
 }
-\examples{
-plot_facets()
-}

--- a/man/process_data.Rd
+++ b/man/process_data.Rd
@@ -14,6 +14,3 @@ process_data(path, old_gpx_format = FALSE)
 \description{
 Processes gpx files and stores the result in a data frame. The code is adapted from the blog post \href{https://rcrastinate.blogspot.com/2014/09/stay-on-track-plotting-gps-tracks-with-r.html}{Stay on track: Plotting GPS tracks with R} by Sascha W.
 }
-\examples{
-process_data()
-}


### PR DESCRIPTION
I removed examples in the documentation that didn't work and were causing errors when running `devtools::check()`. 