### PR TITLE
Correct remote for ggTimeSeries

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,7 +30,7 @@ Imports:
     lubridate,
     ggridges,
     ggthemes,
-    ggTimeSeries,
+    ggTimeSeries (>= 1.0.1),
     packcircles,
     ggforce,
     tidyr,
@@ -39,3 +39,5 @@ License: MIT + file LICENSE
 Encoding: UTF-8
 LazyData: true
 RoxygenNote: 7.1.1
+Remotes:  
+    AtherEnergy/ggTimeSeries


### PR DESCRIPTION
As the {ggTimeSeries} package has been removed from cran (https://cran.r-project.org/web/packages/ggTimeSeries/index.html), the {strava} package can now use the correct remotes.